### PR TITLE
uuid filter added to logs

### DIFF
--- a/lib/chitragupta/chitragupta.js
+++ b/lib/chitragupta/chitragupta.js
@@ -19,7 +19,9 @@ function setupInitialServerData(request, response, userId) {
   cls.set('request', request);
   cls.set('response', response);
   cls.set('userId', userId);
-  cls.set('uuid', request.query.uuid);
+  if(request && request.body) {
+      cls.set('uuid', request.body.uuid);
+  }
 }
 
 function setupResponseOnFinishListener(logger, response) {

--- a/lib/chitragupta/chitragupta.js
+++ b/lib/chitragupta/chitragupta.js
@@ -19,9 +19,6 @@ function setupInitialServerData(request, response, userId) {
   cls.set('request', request);
   cls.set('response', response);
   cls.set('userId', userId);
-  if(request && request.body) {
-      cls.set('uuid', request.body.uuid);
-  }
 }
 
 function setupResponseOnFinishListener(logger, response) {

--- a/lib/chitragupta/chitragupta.js
+++ b/lib/chitragupta/chitragupta.js
@@ -19,6 +19,7 @@ function setupInitialServerData(request, response, userId) {
   cls.set('request', request);
   cls.set('response', response);
   cls.set('userId', userId);
+  cls.set('uuid', request.query.uuid);
 }
 
 function setupResponseOnFinishListener(logger, response) {

--- a/lib/chitragupta/util.js
+++ b/lib/chitragupta/util.js
@@ -10,7 +10,7 @@ function populateServerData(dataParam) {
   data.data.request = data.data.request || {};
   data.data.response = data.data.response || {};
 
-  data.log.uuid = cls.get("uuid") || {};
+  data.log.uuid = cls.get("uuid") || "";
 
   const { url } = request;
   const indexOfQuestionMark = url.indexOf('?');

--- a/lib/chitragupta/util.js
+++ b/lib/chitragupta/util.js
@@ -10,6 +10,8 @@ function populateServerData(dataParam) {
   data.data.request = data.data.request || {};
   data.data.response = data.data.response || {};
 
+  data.log.uuid = cls.get("uuid") || {};
+
   const { url } = request;
   const indexOfQuestionMark = url.indexOf('?');
   let endpoint;
@@ -100,8 +102,6 @@ function initializeData(message, metaDataParam) {
   if (!data.log.kind) {
     data.log.kind = data.log.dynamic_data.substring(0, 40);
   }
-
-  data.log.uuid = cls.get('uuid') || {};
 
   data.meta.format = data.meta.format || {};
 

--- a/lib/chitragupta/util.js
+++ b/lib/chitragupta/util.js
@@ -101,6 +101,8 @@ function initializeData(message, metaDataParam) {
     data.log.kind = data.log.dynamic_data.substring(0, 40);
   }
 
+  data.log.uuid = cls.get('uuid') || {};
+
   data.meta.format = data.meta.format || {};
 
   if (cls.get('server')) populateServerData(data);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chitragupta",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "An easy to install node module to convert unstructured logs into informative structured logs",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
This prs will give extra feature to filter logs for app-uploader by uuid and that's uuid is same as session-id.

What we are resolving? \<[_link to JIRA Story_](https://browserstack.atlassian.net/wiki/spaces/ENG/pages/2469757280/Tailf+Revamp+Chitragupta+-+FAQs#How-to-index-session_id%3F)\>

JIRA Story: \<https://browserstack.atlassian.net/browse/AL-5186\>

#### Related PRs
[_link to browserstack fe_](https://github.com/browserstack/browserstack-fe/pull/599)\>
[_link to app Uploader_](https://github.com/browserstack/app-uploader/pull/1027)\>
[_link to chitragupta node_](https://github.com/browserstack/chitragupta-node/pull/18)\>

### _In app-uploader we need to modify dependency in package.json from_
`"chitragupta": "git+ssh://git@github.com:browserstack/chitragupta-node.git#v1.4.0"`
### _to_
`"chitragupta": "git+ssh://git@github.com:browserstack/chitragupta-node.git#v1.7.2"`


#### Result
After deploying you will see uuid filter in logs for each request which comes to app-uploader.