### PR TITLE
DATA-13529: add hardened .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+ignore-scripts=true
+strict-ssl=true
+save-exact=true
+audit-level=high
+engine-strict=true
+legacy-peer-deps=false

--- a/.npmrc
+++ b/.npmrc
@@ -4,3 +4,4 @@ save-exact=true
 audit-level=high
 engine-strict=true
 legacy-peer-deps=false
+min-release-age=7


### PR DESCRIPTION
Closes the weekly supply-chain `.npmrc` audit finding for this repo (DATA-13529 / SC-12282). Adds the required hardening directives, matching the existing `.npmrc` in `browserstack/dwh_node`.

```ini
ignore-scripts=true
strict-ssl=true
save-exact=true
audit-level=high
engine-strict=true
legacy-peer-deps=false
min-release-age=7
```

### Why this is non-breaking

| Directive | Effect on this repo |
|---|---|
| `ignore-scripts=true` | `package-lock.json` has zero packages with install scripts; `package.json` has no pre/post scripts — no-op |
| `engine-strict=true` | `package.json` has no `engines` field — no-op |
| `save-exact=true` | only affects future `npm install <pkg>`; existing `^` ranges are untouched |
| `audit-level=high` | only changes `npm audit` exit code; the only CI workflow is Semgrep, which does not run `npm audit` |
| `legacy-peer-deps=false` | already npm's default; no `peerDependencies` in the dependency tree |
| `strict-ssl=true` | already npm's default |
| `min-release-age=7` | days, not minutes: only versions published >7 days ago are resolvable. `npm ci` replays the lockfile, and every locked version here is years old — no effect. Added in npm 11.10; older npm just warns the key is unknown. Required by Semgrep rule `npm-missing-minimum-release-age` |

`access=restricted` is intentionally omitted — the audit requires it for private repos only, and this repo is public.

Note: `.npmrc` is never included in a published npm tarball, so consumers are unaffected.

###JIRA
https://browserstack.atlassian.net/browse/DATA-13529
